### PR TITLE
Add a way to delete files in the menu.

### DIFF
--- a/inc/menu.h
+++ b/inc/menu.h
@@ -11,5 +11,7 @@ extern int text_offset;
 void printText(char *msg, int x, int y, display_context_t dcon);
 
 void menu_about(display_context_t disp);
+void menu_controls(display_context_t disp);
+void menu_delete(display_context_t disp, bool isdir);
 
 #endif

--- a/src/menu_about.c
+++ b/src/menu_about.c
@@ -29,30 +29,5 @@ void menu_about(display_context_t disp)
     printText("Conle        Z: Page 2", 9, -1, disp);
     printText("AriaHiro64", 9, -1, disp);
     printText("moparisthebest", 9, -1, disp);
+	printText("Skawo", 9, -1, disp);
 } //TODO: make scrolling text, should include libraries used.
-void menu_controls(display_context_t disp)
-{
-    printText("          - Controls -", 4, 4, disp);
-    printText(" ", 4, -1, disp);
-    printText("      L: brings up the mempak", 4, -1, disp);
-    printText("        menu", 5, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("      Z: about screen", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("      A: start rom/directory", 4, -1, disp);
-    printText("         mempak", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("      B: back/cancel", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("  START: start last rom", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText(" C-left: rom info/mempak", 4, -1, disp);
-    printText("         content view", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("C-right: rom config creen", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText("   C-up: view full filename", 4, -1, disp);
-    printText(" ", 4, -1, disp);
-    printText(" C-down: Toplist 15", 4, -1, disp);
-
-}

--- a/src/menu_controls.c
+++ b/src/menu_controls.c
@@ -1,0 +1,35 @@
+
+#include <libdragon.h>
+#include <stdio.h>
+#include "types.h"
+#include "menu.h"
+#include "version.h"
+#include "main.h"
+#include "everdrive.h"
+
+void menu_controls(display_context_t disp)
+{
+    printText("          - Controls -", 4, 4, disp);
+    printText(" ", 4, -1, disp);
+    printText("      L: show mempak menu", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("      Z: about screen", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("      A: start rom/directory", 4, -1, disp);
+    printText("         mempak", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("      B: back/cancel", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("  START: start last rom", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText(" C-left: rom info/mempak", 4, -1, disp);
+    printText("         content view", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("C-right: rom config creen", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("   C-up: view full filename", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText(" C-down: Toplist 15", 4, -1, disp);
+    printText(" ", 4, -1, disp);
+    printText("  R + L: Delete file", 4, -1, disp);
+}

--- a/src/menu_delete.c
+++ b/src/menu_delete.c
@@ -1,0 +1,25 @@
+
+#include <libdragon.h>
+#include <stdio.h>
+#include "types.h"
+#include "menu.h"
+#include "version.h"
+#include "main.h"
+#include "everdrive.h"
+
+
+void menu_delete(display_context_t disp, bool isdir)
+{	
+	if (isdir)
+	{
+		printText("Cannot delete directories!", 7, 14, disp);
+		printText("B: Exit", 13, 16, disp);	
+	}
+	else
+	{
+		printText("Delete this file?", 10, 14, disp);
+		printText("A: Confirm", 13, 16, disp);
+		printText("B: Cancel", 13, 17, disp);
+		
+	}
+} 

--- a/src/menu_delete.c
+++ b/src/menu_delete.c
@@ -20,6 +20,5 @@ void menu_delete(display_context_t disp, bool isdir)
 		printText("Delete this file?", 10, 14, disp);
 		printText("A: Confirm", 13, 16, disp);
 		printText("B: Cancel", 13, 17, disp);
-		
 	}
 } 


### PR DESCRIPTION
This PR adds a way to delete a file on the SD card from the file browser by choosing a file and pressing L and R simultaneously. The user then has to confirm whether they want to delete the file or not. 

This is useful in case an user accidentally shuts off their game without pressing RESET, creating an empty savefile. Right now, to undo this, one would have to plug their SD card into their computer and delete the offending save there. With this PR they can just do so on console. 

This is also useful in case someone wants to go back to the previous version of the save.